### PR TITLE
Refactored to support back button

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,6 +48,7 @@ I’ve also implemented progressive display of lists. But lots of tools can do t
 
 Navigation between slides is done mostly with keybindings, see
 [the online help](https://saxonica.github.io/SlidesJS/help.html).
+On touch screen devices, gestures are also supported.
 
 ## How
 
@@ -264,15 +265,24 @@ so we can’t capture it directly in XSLT.
 
 My workarounds are mostly in `js/start.js`. 
 
-1. We create a `manageSpeakerNotes` object. That object is local to
-   the window. It’s initialized a little bit carefully so that
-   reloading the page doesn’t accidentally break a running timer.
+1. We setup a `slidesEventQueue`. Everything that the app does, it
+   does in response to state changes added to this queue. This allows
+   the browser window that you’re “driving” with the keyboard and the
+   window that may be tracking changes through the local storage API
+   to work in the same way.
+1. We create a `manageSlides` object. This is a mutable storage object
+   that can be updated by both `start.js` and the SaxonJS application.
+   It’s initialized a little bit carefully so that reloading the page
+   doesn’t accidentally break a running timer.
 2. We register a plain old JavaScript event handler for the storage
-   change event. This handler simply updates the `manageSpeakerNotes`
-   object.
-3. In the stylesheet, we use `ixsl:schedule-action` to setup a
+   change event. This handler adds events to the queue.
+3. We register an “on hash change” event handler that tracks changes
+    to the fragment identifier. This allows the browser back button to
+    work as expected. Like the storage change handler, it works by
+    adding events to the queue.
+4. In the stylesheet, we use `ixsl:schedule-action` to setup a
    template that runs every 50ms. That template inspects the contents
-   of the `manageSpeakerNotes` object and responds accordingly.
+   of the `manageSlides` object and responds accordingly.
    
 (The object is called `manageSpeakerNotes` because it started out as a
 way of managing the presentation of speaker notes in a second browser

--- a/build.gradle
+++ b/build.gradle
@@ -69,18 +69,17 @@ task dist(
   description: "Check that the slidesJSversions match"
 ) {
   inputs.file "${projectDir}/gradle.properties"
-  inputs.file "${projectDir}/src/main/xslt/slides.xsl"
+  inputs.file "${projectDir}/src/main/js/start.js"
   outputs.file "${buildDir}/version"
 
   def getVersion = new ByteArrayOutputStream();
-  commandLine "grep", "xsl:variable.*slidesJSversion",
-    "${projectDir}/src/main/xslt/slides.xsl"
+  commandLine "grep", "const SlidesJSVersion", "${projectDir}/src/main/js/start.js"
   standardOutput = getVersion
   doLast {
     def xslVersion = getVersion.toString("utf-8")
-    def pos = xslVersion.indexOf("'");
+    def pos = xslVersion.indexOf("\"");
     xslVersion = xslVersion.substring(pos+1);
-    pos = xslVersion.indexOf("'");
+    pos = xslVersion.indexOf("\"");
     xslVersion = xslVersion.substring(0, pos);
     def output = new FileWriter(new File("${buildDir}/version"))
     output.write(xslVersion)

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,4 +1,4 @@
-slidesJSversion=1.2.0
+slidesJSversion=1.3.0
 
 xsltCompiler=XX
 saxonVersion=11.3

--- a/src/main/css/slides.css
+++ b/src/main/css/slides.css
@@ -203,6 +203,10 @@ a, a:link, a:visited {
     font-weight: bold;
 }
 
+#slidesjs_time {
+    cursor: pointer;
+}
+
 #slidesjs_time_reset {
     float: right;
     padding-right: 20px;

--- a/src/main/js/start.js
+++ b/src/main/js/start.js
@@ -1,3 +1,5 @@
+const SlidesJSVersion = "1.3.0";
+
 window.onload = function() {
   const defeatTheCache = new Date();
   SaxonJS.transform({
@@ -14,62 +16,100 @@ window.forceHighlight = function() {
 
 let meta = document.querySelector("head meta[name='localStorage.key']");
 const localStorageKey = meta && meta.getAttribute("content");
-const notesKey = "viewingNotes";
-let notesView = false;
 
-window.manageSpeakerNotes = {
-  "reload": new Date().toString(),
-  "navigated": false,
-  "currentPage": window.location.href,
-  "reveal": false,
-  "unreveal": false,
+window.slidesEventQueue = [];
+
+window.slidesPushEvent = function(state, value) {
+  window.slidesEventQueue.push({'state': state, 'value': value});
+  if (localStorageKey) {
+    window.localStorage.setItem(`${localStorageKey}.${state}`, value);
+  }
+};
+
+window.slidesPopEvent = function() {
+  return window.slidesEventQueue.shift();
+};
+
+window.manageSlides = {
+  "slidesJSVersion": SlidesJSVersion,
   "showNotes": false,
   "duration": 'PT0S',
   "startTime": "",
   "paused": true,
+  "last-reveal": "",
+  "last-unreveal": "",
+  "last-reveal-all": "",
   "touchX": 0,
-  "touchY": 0,
-  "touchSwipe": ""
+  "touchY": 0
+};
+
+if (localStorageKey) {
+  if (window.localStorage.getItem(`${localStorageKey}.version`) !== SlidesJSVersion) {
+    for (let key in Object.keys(window.localStorage)) {
+      if (key.startsWith(localStorageKey+".")) {
+        window.localStorage.removeItem(key);
+      }
+    }
+    window.localStorage.setItem(`${localStorageKey}.version`, SlidesJSVersion);
+  }
+}
+
+// If we open a URI without a fragment identifier, we're immediately
+// redirected to one that ends with a bare #. This causes an annoying
+// flicker when multiple browser windows are open, so just normalize
+// the location so that it always has a fragment identifier.
+// (Candidly, I don't much like the trailing empty fragid on the
+// title page, but it's not worth fussing about.)
+const normalizedLocation = function(loc) {
+  if (!loc) {
+    loc = location.href;
+  }
+  if (loc.indexOf("#") >= 0) {
+    return loc;
+  } else {
+    return loc + "#";
+  }
 };
 
 const storageChange = function(changes, areaName) {
   if (changes.key.startsWith(localStorageKey)) {
     const key = changes.key.substring(localStorageKey.length + 1);
-    if (window.manageSpeakerNotes[key] !== changes.newValue) {
-      window.manageSpeakerNotes[key] = changes.newValue;
+    // Changes to the current page are managed with the location.href
+    if (key === "currentPage") {
+      if (normalizedLocation() !== normalizedLocation(changes.newValue)) {
+        location.href = normalizedLocation(changes.newValue);
+      }
+    } else {
+      window.slidesEventQueue.push({'state': key, 'value': changes.newValue});
     }
   }
 };
 
-if (localStorageKey) {
-  const dt = new Date().toString();
-  window.localStorage.setItem(`${localStorageKey}.currentPage`, window.location.href);
-  window.localStorage.setItem(`${localStorageKey}.reveal`, "");
-  window.localStorage.setItem(`${localStorageKey}.unreveal`, "");
-  window.localStorage.setItem(`${localStorageKey}.reload`, dt);
-
-  let duration = window.localStorage.getItem(`${localStorageKey}.duration`);
-  if (duration == null) {
-    window.localStorage.setItem(`${localStorageKey}.duration`, "PT0S");
-  } else {
-    window.manageSpeakerNotes.duration = duration;
-  }
-
-  let startTime = window.localStorage.getItem(`${localStorageKey}.startTime`);
-  // There was a bug in 1.1.0 that meant startTime could sometimes
-  // incorrectly get initialized to 'true' instead of a dateTime
-  if (startTime === null || startTime === "true") {
-    startTime = new Date().toISOString();
-    window.localStorage.setItem(`${localStorageKey}.startTime`, startTime);
-  }
-  window.manageSpeakerNotes.startTime = startTime;
-
-  let paused = window.localStorage.getItem(`${localStorageKey}.paused`);
-  if (paused == null) {
-    paused = "true";
-    window.localStorage.setItem(`${localStorageKey}.paused`, paused);
-  }
-  window.manageSpeakerNotes.paused = (paused == "true");
-
-  window.addEventListener("storage", storageChange);
+const hashChange = function(event) {
+  // Defer hash changes to the storage change function so
+  // that they're handled in one place.
+  window.slidesPushEvent("currentPage", normalizedLocation());
 };
+
+window.slidesPushEvent("currentPage", normalizedLocation());
+
+let now = new Date().toString();
+window.slidesPushEvent("reload", now);
+
+let duration = (localStorageKey
+                ? window.localStorage.getItem(`${localStorageKey}.duration`)
+                : "PT0S");
+window.slidesPushEvent("duration", duration == null ? "PT0S" : duration);
+
+let startTime = (localStorageKey
+                 ? window.localStorage.getItem(`${localStorageKey}.startTime`)
+                 : now);
+window.slidesPushEvent("startTime", startTime);
+
+let paused = (localStorageKey
+              ? window.localStorage.getItem(`${localStorageKey}.paused`)
+              : 'true');
+window.slidesPushEvent("paused", paused === "true");
+
+window.addEventListener("storage", storageChange);
+window.addEventListener("hashchange", hashChange);


### PR DESCRIPTION
It bugged me that the back button didn't work. To fix it, I decided to refactor things so that the slide presentation is driven entirely by an event queue. This has the advantage that the rendering is the same for both the "primary" window, where navigation occurs, and any windows(s) that are being updated by changes to local storage.

Along the way, I decided that there were some potential race conditions created by having two event loops, one for the user actions and one to update the timer, so I made updating the timer part of the single event loop that consumes events from the queue.

And I improved the gesture behaviors. The edges of the screen are now 20% instead of 10%. Any swiping motion that covers less than 5% of the screen is ignored. This avoids spurious motion when the screen is tapped.

Fix #1 
Fix #2 
